### PR TITLE
Fix tenant context usage by removing transactional proxies

### DIFF
--- a/src/main/java/com/example/multitenant/customer/CustomerService.java
+++ b/src/main/java/com/example/multitenant/customer/CustomerService.java
@@ -5,7 +5,6 @@ import com.example.multitenant.config.TenantContextHolder;
 import java.util.List;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CustomerService {
@@ -16,17 +15,14 @@ public class CustomerService {
         this.repository = repository;
     }
 
-    @Transactional
     public Customer createCustomer(String tenant, String name) {
         return executeInContext(tenant, DataSourceType.WRITE, () -> repository.save(name));
     }
 
-    @Transactional(readOnly = true)
     public List<Customer> findAll(String tenant) {
         return executeInContext(tenant, DataSourceType.READ, repository::findAll);
     }
 
-    @Transactional
     public void deleteAll(String tenant) {
         executeInContext(tenant, DataSourceType.WRITE, () -> {
             repository.deleteAll();

--- a/src/main/java/com/example/multitenant/customer/RestExceptionHandler.java
+++ b/src/main/java/com/example/multitenant/customer/RestExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.example.multitenant.customer;
+
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+class RestExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    ResponseEntity<Map<String, String>> handleValidationError(MethodArgumentNotValidException exception) {
+        String message = exception.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(error -> error.getDefaultMessage())
+                .orElse("Validation failed");
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("message", message));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure tenant and data source context is applied before each repository call by removing the transactional proxy boundaries from the customer service methods
- add a REST exception handler that returns validation error messages in the response body

## Testing
- gradle test *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" while downloading Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68cafd722fe883308ce708e3c65c5468